### PR TITLE
fix: pass GITHUB_TOKEN as input to composite release action

### DIFF
--- a/.github/actions/prepare-release/action.yml
+++ b/.github/actions/prepare-release/action.yml
@@ -5,6 +5,9 @@ inputs:
   version:
     description: 'Version string'
     required: true
+  GITHUB_TOKEN:
+    description: 'GitHub token for authentication'
+    required: true
 
 outputs:
   release_notes:
@@ -61,4 +64,4 @@ runs:
         files: release/*
         body: ${{ steps.release_notes.outputs.content }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -118,6 +118,7 @@ jobs:
         uses: ./.github/actions/prepare-release
         with:
           version: ${{ needs.prepare.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Summary job (always runs)
   summary:


### PR DESCRIPTION
composite actions cannot directly access the secrets context; GITHUB_TOKEN must be explicitly passed as an input and referenced as inputs.GITHUB_TOKEN instead of secrets.GITHUB_TOKEN for softprops/action-gh-release authentication